### PR TITLE
Fix: Return type of _call_eas to bytes

### DIFF
--- a/libs/community/langchain_community/chat_models/pai_eas_endpoint.py
+++ b/libs/community/langchain_community/chat_models/pai_eas_endpoint.py
@@ -208,7 +208,8 @@ class PaiEasChatEndpoint(BaseChatModel):
 
         return generated_text
 
-    def _call_eas(self, query_body: dict) -> Any:
+
+    def _call_eas(self, query_body: dict) -> bytes:
         """Generate text from the eas service."""
         headers = {
             "Content-Type": "application/json",
@@ -227,7 +228,7 @@ class PaiEasChatEndpoint(BaseChatModel):
                 f" and message {response.text}"
             )
 
-        return response.text
+        return response.content  # Return bytes
 
     def _call_eas_stream(self, query_body: dict) -> Any:
         """Generate text from the eas service."""


### PR DESCRIPTION
This PR changes the return type of the _call_eas method from str to bytes to align with expected data handling.