### PR TITLE
Fix return type in _call_eas to return bytes instead of str

### DIFF
--- a/libs/community/langchain_community/chat_models/pai_eas_endpoint.py
+++ b/libs/community/langchain_community/chat_models/pai_eas_endpoint.py
@@ -227,6 +227,8 @@ class PaiEasChatEndpoint(BaseChatModel):
                 f" and message {response.text}"
             )
 
+        return response.content  # Changed from response.text to response.content
+
         return response.text
 
     def _call_eas_stream(self, query_body: dict) -> Any:


### PR DESCRIPTION
This PR fixes the issue where the _call_eas method was incorrectly returning a string instead of bytes. This change aligns with the expected behavior as described in the issue #20453.