### PR TITLE
Fix: Change _call_eas to return bytes instead of str

### DIFF
--- a/libs/community/langchain_community/chat_models/pai_eas_endpoint.py
+++ b/libs/community/langchain_community/chat_models/pai_eas_endpoint.py
@@ -208,6 +208,7 @@ class PaiEasChatEndpoint(BaseChatModel):
 
         return generated_text
 
+
     def _call_eas(self, query_body: dict) -> Any:
         """Generate text from the eas service."""
         headers = {
@@ -227,7 +228,7 @@ class PaiEasChatEndpoint(BaseChatModel):
                 f" and message {response.text}"
             )
 
-        return response.text
+        return response.content
 
     def _call_eas_stream(self, query_body: dict) -> Any:
         """Generate text from the eas service."""


### PR DESCRIPTION
This PR addresses issue #20453 by changing the return type of _call_eas from str to bytes.