### PR TITLE
Fix Issue #20453: Change _call_eas to return bytes instead of str

### DIFF
--- a/libs/community/langchain_community/chat_models/pai_eas_endpoint.py
+++ b/libs/community/langchain_community/chat_models/pai_eas_endpoint.py
@@ -215,19 +215,15 @@ class PaiEasChatEndpoint(BaseChatModel):
             "Accept": "application/json",
             "Authorization": f"{self.eas_service_token}",
         }
-
         # make request
         response = requests.post(
             self.eas_service_url, headers=headers, json=query_body, timeout=self.timeout
         )
-
         if response.status_code != 200:
             raise Exception(
-                f"Request failed with status code {response.status_code}"
-                f" and message {response.text}"
+                f"Request failed with status code {response.status_code}" f" and message {response.text}"
             )
-
-        return response.text
+        return response.content
 
     def _call_eas_stream(self, query_body: dict) -> Any:
         """Generate text from the eas service."""


### PR DESCRIPTION
This pull request addresses issue #20453 by modifying the `_call_eas` method to return `bytes` instead of `str`.